### PR TITLE
remove accents when the word finish with vowel+n|s

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,11 @@ module.exports = function(str) {
     //easy, just add s
     plural = str + 's';
   }
+  else if (last_letter === 's') {
+    //if the word ends with S but is not aguda
+    //(accented in the last syllabe)
+    plural = str;
+  }
   else {
     plural = str + 'es';
   }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,20 @@
 'use strict';
 
+var removeAccents = require('remove-accents')
+var vowels = 'aeiou'.split('');
+
+function isVowel(char) {
+  var result = char.length === 1 &&
+      vowels.indexOf(removeAccents(char)) > -1;
+  return result;
+}
+
 module.exports = function(str) {
   //info can be found here:
   //http://lema.rae.es/dpd/?key=plural&lema=plural
   //http://www.studyspanish.com/lessons/plnoun.htm
   //http://www.spanishdict.com/topics/show/3
-  
+
   //some things are conflicting though so there might be some issues.
 
   var plural;
@@ -18,30 +27,9 @@ module.exports = function(str) {
     plural = str;
   }
 
-  if (last_letter === 's') {
-    switch (str) {
-      case 'pies':
-        plural = 'pieses';
-        break;
-      case 'cafés':
-        plural = 'cafeses';
-        break;
-      case 'acortamientos':
-        plural = 'acortamiento';
-        break;
-      case 'abreviaturas':
-        plural = 'abreviatura';
-        break;
-      case 'siglas':
-        plural = 'sigla';
-        break;
-      case 'símbolos':
-        plural = 'símbolo';
-        break;
-      default:
-        //normally though it doesn't change
-        plural = str;
-    }
+  if (last_2_letters.match(/[áéíóú](n|s)$/)) {
+    var radical = removeAccents(str);
+    plural = radical + 'es';
   }
   else if (last_letter === 'z') {
     //drop the z and add ces
@@ -57,32 +45,13 @@ module.exports = function(str) {
     //add an extra u
     plural = str + 'ues';
   }
-  else if (last_letter === 'a' || last_letter === 'e' || last_letter === 'é' || last_letter === 'i' || last_letter === 'o' || last_letter === 'u') {
+  else if (isVowel(last_letter)) {
     //easy, just add s
     plural = str + 's';
-
   }
-  else if (last_letter === 'á') {
-    var radical = str.substring(0, str.length - 1);
-    plural = radical + 'aes';
-
-  }
-  else if (last_letter === 'ó') {
-    var radical = str.substring(0, str.length - 1);
-    plural = radical + 'oes';
-
-  }
-  else if (last_3_letters === 'ión') {
-    var radical = str.substring(0, str.length - 3);
-    plural = radical + 'iones';
-  }
-  else if (last_2_letters === 'ín') {
-    var radical = str.substring(0, str.length - 2);
-    plural = radical + 'ines';
-  }
-
   else {
     plural = str + 'es';
   }
+
   return plural;
 };

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "ava": "0.0.4"
+  },
+  "dependencies": {
+    "remove-accents": "^0.4.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -11,8 +11,11 @@ test(function (t) {
     t.assert(pluralize('pluma') === 'plumas');
     t.assert(pluralize('universidad') === 'universidades');
     t.assert(pluralize('café') === 'cafés');
-    t.assert(pluralize('bongó') === 'bongoes');
+    t.assert(pluralize('bongó') === 'bongós');
     t.assert(pluralize('zigzag') === 'zigzagues');
     t.assert(pluralize('frac') === 'fraques');
+    t.assert(pluralize('bastón') === 'bastones');
+    t.assert(pluralize('cajón') === 'cajones');
+    t.assert(pluralize('país') === 'paises');
     t.end();
 });

--- a/test.js
+++ b/test.js
@@ -17,5 +17,6 @@ test(function (t) {
     t.assert(pluralize('bastón') === 'bastones');
     t.assert(pluralize('cajón') === 'cajones');
     t.assert(pluralize('país') === 'paises');
+    t.assert(pluralize('lunes') === 'lunes');
     t.end();
 });


### PR DESCRIPTION
I fixed the case of `país` to `paises` reported in #2 differently than the other pull-request. I am not sure but I think is not an exception, if the word ends with ACCENTED VOWEL+N|S we have to remove the accent and add `es`. 

Examples:
- `cajón => cajones`
- `bastón => bastones`
- `canción => canciones`
- `país => paises`
- `pantalón => pantalones`
- `obús => obuses`

If the word ends with `s` but is not aguda (accented in the last syllable) the plural is the same than the singular like lunes, viernes, etc.

I also fixed `bongó` => `bongós`